### PR TITLE
Greenkeeper/@octokit/routes 19.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -214,9 +214,9 @@
       }
     },
     "@octokit/routes": {
-      "version": "19.1.3",
-      "resolved": "https://registry.npmjs.org/@octokit/routes/-/routes-19.1.3.tgz",
-      "integrity": "sha512-PoCFUayM1tVJpemKI5RH91nh5WIoXjJDHRZgMZ9BsuoZg7pEOMX3M/YZAT2y25ab/fjb9NE+AqDfZC4T5Z7erQ==",
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/@octokit/routes/-/routes-19.3.0.tgz",
+      "integrity": "sha512-uhnqvSURAXVnPHgW/puR6B2nhzPJSfV+CgM5z9zhNBxQxZLyjls5aax93HXFbbSOJ4kl/oQ4Odb8oPikec9e/A==",
       "dev": true,
       "requires": {
         "cheerio": "^1.0.0-rc.2",
@@ -538,9 +538,9 @@
       "dev": true
     },
     "acorn-globals": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz",
-      "integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.1.tgz",
+      "integrity": "sha512-gJSiKY8dBIjV/0jagZIFBdVMtfQyA5QHCvAT48H2q8REQoW8Fs5AOjqBql1LgSXgrMWdevcE+8cdZ33NtVbIBA==",
       "dev": true,
       "requires": {
         "acorn": "^6.0.1",
@@ -1111,13 +1111,13 @@
       "dev": true
     },
     "cheerio": {
-      "version": "1.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
-      "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
+      "integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
       "dev": true,
       "requires": {
         "css-select": "~1.2.0",
-        "dom-serializer": "~0.1.0",
+        "dom-serializer": "~0.1.1",
         "entities": "~1.1.1",
         "htmlparser2": "^3.9.1",
         "lodash": "^4.15.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/octokit/plugin-scim.js#readme",
   "devDependencies": {
-    "@octokit/routes": "19.1.3",
+    "@octokit/routes": "19.3.0",
     "coveralls": "^3.0.2",
     "lodash.camelcase": "^4.3.0",
     "semantic-release": "^15.13.8",

--- a/routes.json
+++ b/routes.json
@@ -3,15 +3,28 @@
     "method": "GET",
     "params": {
       "external_identity_guid": {
-        "required": true,
-        "type": "string"
+        "deprecated": {
+          "after": {
+            "name": "scim_user_id"
+          },
+          "before": {
+            "name": "external_identity_guid"
+          },
+          "date": "2019-04-10",
+          "message": "\"external_identity_guid\" parameter renamed to \"scim_user_id\""
+        },
+        "type": "integer"
       },
       "org": {
         "required": true,
         "type": "string"
+      },
+      "scim_user_id": {
+        "required": true,
+        "type": "integer"
       }
     },
-    "url": "/scim/v2/organizations/:org/Users/:external_identity_guid"
+    "url": "/scim/v2/organizations/:org/Users/:scim_user_id"
   },
   "listProvisionedIdentities": {
     "method": "GET",
@@ -56,42 +69,108 @@
     "method": "DELETE",
     "params": {
       "external_identity_guid": {
-        "required": true,
-        "type": "string"
+        "deprecated": {
+          "after": {
+            "name": "scim_user_id"
+          },
+          "before": {
+            "name": "external_identity_guid"
+          },
+          "date": "2019-04-10",
+          "message": "\"external_identity_guid\" parameter renamed to \"scim_user_id\""
+        },
+        "type": "integer"
       },
       "org": {
         "required": true,
         "type": "string"
+      },
+      "scim_user_id": {
+        "required": true,
+        "type": "integer"
       }
     },
-    "url": "/scim/v2/organizations/:org/Users/:external_identity_guid"
+    "url": "/scim/v2/organizations/:org/Users/:scim_user_id"
+  },
+  "replaceProvisionedUserInformation": {
+    "method": "PUT",
+    "params": {
+      "external_identity_guid": {
+        "deprecated": {
+          "after": {
+            "name": "scim_user_id"
+          },
+          "before": {
+            "name": "external_identity_guid"
+          },
+          "date": "2019-04-10",
+          "message": "\"external_identity_guid\" parameter renamed to \"scim_user_id\""
+        },
+        "type": "integer"
+      },
+      "org": {
+        "required": true,
+        "type": "string"
+      },
+      "scim_user_id": {
+        "required": true,
+        "type": "integer"
+      }
+    },
+    "url": "/scim/v2/organizations/:org/Users/:scim_user_id"
   },
   "updateProvisionedOrgMembership": {
     "method": "PUT",
     "params": {
       "external_identity_guid": {
-        "required": true,
-        "type": "string"
+        "deprecated": {
+          "after": {
+            "name": "scim_user_id"
+          },
+          "before": {
+            "name": "external_identity_guid"
+          },
+          "date": "2019-04-10",
+          "message": "\"external_identity_guid\" parameter renamed to \"scim_user_id\""
+        },
+        "type": "integer"
       },
       "org": {
         "required": true,
         "type": "string"
+      },
+      "scim_user_id": {
+        "required": true,
+        "type": "integer"
       }
     },
-    "url": "/scim/v2/organizations/:org/Users/:external_identity_guid"
+    "url": "/scim/v2/organizations/:org/Users/:scim_user_id"
   },
   "updateUserAttribute": {
     "method": "PATCH",
     "params": {
       "external_identity_guid": {
-        "required": true,
-        "type": "string"
+        "deprecated": {
+          "after": {
+            "name": "scim_user_id"
+          },
+          "before": {
+            "name": "external_identity_guid"
+          },
+          "date": "2019-04-10",
+          "message": "\"external_identity_guid\" parameter renamed to \"scim_user_id\""
+        },
+        "type": "integer"
       },
       "org": {
         "required": true,
         "type": "string"
+      },
+      "scim_user_id": {
+        "required": true,
+        "type": "integer"
       }
     },
-    "url": "/scim/v2/organizations/:org/Users/:external_identity_guid"
+    "url": "/scim/v2/organizations/:org/Users/:scim_user_id"
   }
 }


### PR DESCRIPTION
- [ ] `external_identity_guid` property should just have `"alias": "scim_user_id"` and `"deprecated": true` properties. It currently has

  ```json
  "deprecated": {
    "after": {
      "name": "scim_user_id"
    },
    "before": {
      "name": "external_identity_guid"
    },
    "date": "2019-04-10",
    "message": "\"external_identity_guid\" parameter renamed to \"scim_user_id\""
  },
  ```

closes #44 
