### PR TITLE
fix npm package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ```js
 const Octokit = require('@octokit/rest')
-  .plugin(require('@octokit/scim-routes'))
+  .plugin(require('@octokit/plugin-scim'))
 const octokit = new Octokit()
 
 octokit.scim.listProvisionedIdentities({


### PR DESCRIPTION
The readme listed the wrong name for the npm package.

```console
$ npm install @octokit/scim-routes
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/@octokit%2fscim-routes - Not found
npm ERR! 404 
npm ERR! 404  '@octokit/scim-routes@latest' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
npm ERR! 404 
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/XXXX/.npm/_logs/2019-07-03T10_23_56_790Z-debug.log
```
```console
$ npm install @octokit/plugin-scim
+ @octokit/plugin-scim@2.2.0
added 1 package from 1 contributor and audited 113 packages in 3.48s
found 0 vulnerabilities
```